### PR TITLE
ghvmctl: Save multiple screenshots keeping timestamps

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,6 +37,15 @@ jobs:
           ghvmctl install-snap kubectl
 
           ghvmctl run-snap signal-desktop
+          sleep 2
           ghvmctl screenshot-full
           ghvmctl screenshot-window
+          ls -lht "$HOME"/ghvmctl-screenshots
           ghvmctl exec "cat /home/ubuntu/signal-desktop.log"
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v3
+        with:
+          name: screenshots
+          path: ~/ghvmctl-screenshots
+          if-no-files-found: error

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,6 +40,7 @@ jobs:
           sleep 2
           ghvmctl screenshot-full
           ghvmctl screenshot-window
+          ghvmctl screenshot-full
           ls -lht "$HOME"/ghvmctl-screenshots
           ghvmctl exec "cat /home/ubuntu/signal-desktop.log"
 

--- a/src/ghvmctl
+++ b/src/ghvmctl
@@ -50,7 +50,7 @@ screenshot_full() {
 	info "Taking a screenshot of the full screen inside the VM"
 	mkdir -p "${SCREENSHOTS_PATH}"
 	# Take a screenshot of the whole screen in the VM
-	timestamp=$(date +'%Y-%m-%d_%H%M%S')
+	timestamp="$(date +'%Y-%m-%d_%H%M%S')"
 	exec_in_vm "gnome-screenshot -f /home/ubuntu/screen.png"
 	# Pull the screenshot back to the host
 	output="screenshot-screen-$timestamp.png"

--- a/src/ghvmctl
+++ b/src/ghvmctl
@@ -10,6 +10,8 @@ VM_CPUS="${VM_CPUS:=1}"
 VM_MEM_GIB="${VM_MEM_GIB:=6}"
 VM_DISK_GIB="${VM_DISK_GIB:=12}"
 
+SCREENSHOTS_PATH="${SNAP_REAL_HOME}/ghvmctl-screenshots"
+
 # Starts a desktop VM and waits for the agent to be running inside.
 prepare_vm() {
 	info "Launching VM '${VM_NAME}' with LXD"
@@ -43,25 +45,31 @@ exec_in_vm() {
 }
 
 # Takes a screenshot of the full screen and pulls the file back from the VM to a file
-# named "screenshot-screen.png", and uploads to imgur, returning the URL
+# named "screenshot-screen-$TIMESTAMP.png", last file is linked as "screenshot-screen.png".
 screenshot_full() {
 	info "Taking a screenshot of the full screen inside the VM"
-	mkdir -p "${SNAP_REAL_HOME}/ghvmctl-screenshots"
+	mkdir -p "${SCREENSHOTS_PATH}"
 	# Take a screenshot of the whole screen in the VM
+	timestamp=$(date +'%Y-%m-%d_%H%M%S')
 	exec_in_vm "gnome-screenshot -f /home/ubuntu/screen.png"
 	# Pull the screenshot back to the host
-	lxc file pull test-vm/home/ubuntu/screen.png "${SNAP_REAL_HOME}/ghvmctl-screenshots/screenshot-screen.png"
+	output="screenshot-screen-$timestamp.png"
+	lxc file pull "${VM_NAME}/home/ubuntu/screen.png" "${SCREENSHOTS_PATH}/$output"
+	ln -sf "$output" "${SCREENSHOTS_PATH}/screenshot-screen.png"
 }
 
 # Takes a screenshot of the active window and pulls the file back from the VM to a file
-# named "screenshot-window.png", and uploads to imgur, returning the URL
+# named "screenshot-window-$TIMESTAMP.png", last file is linked as "screenshot-window.png".
 screenshot_window() {
 	info "Taking a screenshot of the active window inside the VM"
-	mkdir -p "${SNAP_REAL_HOME}/ghvmctl-screenshots"
+	mkdir -p "${SCREENSHOTS_PATH}"
 	# Take a screenshot of the active window in the VM
+	timestamp=$(date +'%Y-%m-%d_%H%M%S')
 	exec_in_vm "gnome-screenshot -w -f /home/ubuntu/window.png"
 	# Pull the screenshot back to the host
-	lxc file pull test-vm/home/ubuntu/window.png "${SNAP_REAL_HOME}/ghvmctl-screenshots/screenshot-window.png"
+	output="screenshot-window-$timestamp.png"
+	lxc file pull "${VM_NAME}/home/ubuntu/window.png" "${SCREENSHOTS_PATH}/$output"
+	ln -sf "$output" "${SCREENSHOTS_PATH}/screenshot-window.png"
 }
 
 # Print the usage statement and exit the program

--- a/src/ghvmctl
+++ b/src/ghvmctl
@@ -64,7 +64,7 @@ screenshot_window() {
 	info "Taking a screenshot of the active window inside the VM"
 	mkdir -p "${SCREENSHOTS_PATH}"
 	# Take a screenshot of the active window in the VM
-	timestamp=$(date +'%Y-%m-%d_%H%M%S')
+	timestamp="$(date +'%Y-%m-%d_%H%M%S')"
 	exec_in_vm "gnome-screenshot -w -f /home/ubuntu/window.png"
 	# Pull the screenshot back to the host
 	output="screenshot-window-$timestamp.png"


### PR DESCRIPTION
Make possible to save more screenshot during a single run, without
overwriting them, while keeping a symbolic link to the latest that has
been taken using the canonical names not to break expectations.

Also, add CI job to save them.

Sadly, the saved screenshots are not containing the app running right now, due to some other issue, since this definitely work in an lxd instance launched locally (and the app is actually running `ps`'ing it).