### PR TITLE
ghvmctl: Add commands to check if snap is running, to stop or kill it

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,11 +32,15 @@ jobs:
 
           ghvmctl prepare
 
-          ghvmctl install-snap signal-desktop --channel candidate
-          ghvmctl install-snap terraform --revision 584
-          ghvmctl install-snap kubectl
+          ghvmctl snap-install signal-desktop --channel candidate
+          ghvmctl snap-install terraform --revision 584
+          ghvmctl snap-install kubectl
 
-          ghvmctl run-snap signal-desktop
+          # Check deprecated commands
+          ghvmctl install-snap hello
+          ghvmctl run-snap hello
+
+          ghvmctl snap-run signal-desktop
           ghvmctl screenshot-full
           ghvmctl screenshot-window
           ghvmctl exec "cat /home/ubuntu/signal-desktop.log"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,4 +43,12 @@ jobs:
           ghvmctl snap-run signal-desktop
           ghvmctl screenshot-full
           ghvmctl screenshot-window
+
+          ghvmctl snap-is-running signal-desktop
+          ghvmctl snap-is-running terraform && exit 1 || true
+
+          ghvmctl snap-terminate signal-desktop
+          ghvmctl snap-is-running signal-desktop && exit 1 || true
+          ghvmctl snap-kill kubectl && exit 1 || true
+
           ghvmctl exec "cat /home/ubuntu/signal-desktop.log"

--- a/src/ghvmctl
+++ b/src/ghvmctl
@@ -83,7 +83,7 @@ SUBCOMMANDS:
 		  ghvmctl exec "cat /etc/hostname"
 		  ghvmctl exec "sudo apt update"
 
-	install-snap <snap name> [-c|--channel <channel>] [-r|--revision <revision>]
+	snap-install <snap name> [-c|--channel <channel>] [-r|--revision <revision>]
 		Installs the specified snap inside the VM.
 
 		Examples:
@@ -91,7 +91,7 @@ SUBCOMMANDS:
 		  ghvmctl install snap signal-desktop --channel candidate
 		  ghvmctl install snap signal-desktop --revision 554
 
-	run-snap <snap name>
+	snap-run <snap name>
 		Runs the specified snap inside the VM. Outputs stdout/stderr to a file
 		inside the VM at /home/ubuntu/<snap name>.log.
 
@@ -116,6 +116,12 @@ if [[ -z $command ]]; then
 	usage
 fi
 
+function check_deprecated_command() {
+	if  [[ "$1" == *-snap ]]; then
+		echo "$0: $1 is deprecated, use snap-${1%-snap} instead."
+	fi
+}
+
 case "$command" in
 "prepare")
 	prepare_vm
@@ -123,10 +129,12 @@ case "$command" in
 "exec")
 	exec_in_vm "$@"
 	;;
-"run-snap")
+"snap-run"|"run-snap")
+	check_deprecated_command "$command"
 	exec_in_vm "snap run $1 &>/home/ubuntu/$1.log &"
 	;;
-"install-snap")
+"snap-install"|"install-snap")
+	check_deprecated_command "$command"
 	snap_name="$1"
 	shift
 

--- a/src/ghvmctl
+++ b/src/ghvmctl
@@ -94,9 +94,31 @@ SUBCOMMANDS:
 	snap-run <snap name>
 		Runs the specified snap inside the VM. Outputs stdout/stderr to a file
 		inside the VM at /home/ubuntu/<snap name>.log.
+		Only one instance of a single snap can run.
 
 		Examples:
 		  ghvmctl run-snap signal-desktop
+
+	snap-is-running <snap name>
+		Checks whether the provided snap is currently running.
+		Exits with a non-zero value if this is not the case.
+
+		Examples:
+		  ghvmctl snap-is-running signal-desktop
+
+	snap-terminate <snap name>
+		Terminates the provided snap, waiting for it to be stopped.
+		Exits with a non-zero value if the snap is not running or stop fails.
+
+		Examples:
+		  ghvmctl snap-terminate signal-desktop
+
+	snap-kill <snap name>
+		Kills the provided snap (using SIGKILL), and waits for completion.
+		Exits with a non-zero value if the snap is not running.
+
+		Examples:
+		  ghvmctl snap-kill signal-desktop
 
 	screenshot-full
 		Takes a full-screen screenshot of the virtual machine. Places the output
@@ -131,6 +153,10 @@ case "$command" in
 	;;
 "snap-run"|"run-snap")
 	check_deprecated_command "$command"
+	if exec_in_vm systemctl -q --user is-active "snap.$1.*"; then
+		echo "$1 is already running"
+		exit 1
+	fi
 	exec_in_vm "snap run $1 &>/home/ubuntu/$1.log &"
 	;;
 "snap-install"|"install-snap")
@@ -160,6 +186,31 @@ case "$command" in
 				;;
 		esac
 	done
+	;;
+"snap-is-running")
+	snap_name="$1"
+	if ! exec_in_vm systemctl -q --user is-active "snap.$snap_name.*"; then
+		echo Process for "$snap_name" not running.
+		exit 1;
+	fi
+	;;
+"snap-terminate")
+	snap_name="$1"
+	if ! exec_in_vm systemctl -q --user is-active "snap.$snap_name.*"; then
+		echo Process for "$snap_name" not running.
+		exit 1;
+	fi
+	exec_in_vm systemctl --user stop "snap.$snap_name.*"
+	shift
+	;;
+"snap-kill")
+	snap_name="$1"
+	if ! exec_in_vm systemctl -q --user is-active "snap.$snap_name.*"; then
+		echo Process for "$snap_name" not running.
+		exit 1;
+	fi
+	exec_in_vm systemctl --user kill -s 9 "snap.$snap_name.*"
+	shift
 	;;
 "screenshot-full")
 	screenshot_full


### PR DESCRIPTION
It may be relevant to check if a snap is still running after a while,
this may not be the case in case of crashes, so add ability to check
this.

At the same time add commands to stop or kill a snap, by using systemd
so that we don't have to deal on all the subprocesses around.

Also, deprecate `*-snap` commands in favor of `snap-` prefixed ones to be consistent and more predictable.

CI checks here ensure that the snap works, even though as stated already in #1 and #2 the screenshots may not show it. :open_mouth: 