### PR TITLE
ci: add repo-token to release workflow to enable tagged revisions

### DIFF
--- a/.github/workflows/release-to-candidate.yaml
+++ b/.github/workflows/release-to-candidate.yaml
@@ -39,6 +39,7 @@ jobs:
         with:
           architecture: ${{ matrix.architecture }}
           launchpad-token: ${{ secrets.LP_BUILD_SECRET }}
+          repo-token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           store-token: ${{ secrets.SNAP_STORE_CANDIDATE }}
 
   call-for-testing:


### PR DESCRIPTION
Add a new parameter to the release workflow so that tags can be created automatically for each released revision